### PR TITLE
timeline.py: Add trigger sorting

### DIFF
--- a/evfl/timeline.py
+++ b/evfl/timeline.py
@@ -254,6 +254,7 @@ class Timeline(BinaryObject):
             t.clip.set_index(clip_to_idx)
 
     def _do_write(self, stream: WriteStream) -> None:
+        self.triggers.sort(key=lambda a: a.clip.v.start_time + (a.type-1) * a.clip.v.duration)
         self._set_indexes_from_values()
 
         for actor in self.actors:


### PR DESCRIPTION
The only `type`s I've observed are 1 for Entry, and 2 for Leave. This exploits that to sort both in a lambda function, but that will obviously fail if there's more `type`s than those two. I don't see what other types there could be, at least not for a trigger, but I can make it a whole function if you think there's a need for that.